### PR TITLE
Created cloudbuild.yaml file

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,7 @@
+steps:
+#builds the image
+- name: 'docker'
+  args: ['build','-t','gcr.io/$PROJECT_ID/gcpdevops','.']
+#uploads the image to the artifact container registry in folder gcpdevops
+images:
+- 'gcr.io/$PROJECT_ID/gcpdevops'


### PR DESCRIPTION
The function of the cloudbuild.yaml file is to build docker image of the application and save the image to the gcr.io container registry (in folder gcpdevops) using GCP's Artifact Registry. 